### PR TITLE
Fixed paths. Use .path not .path() for file system.

### DIFF
--- a/Sources/TikTokenSwift/Vocab.swift
+++ b/Sources/TikTokenSwift/Vocab.swift
@@ -44,7 +44,7 @@ internal struct Vocab {
         }
         if let vocabUrl = try getLocalVocabLocation() {
             if #available(iOS 16.0, *) {
-                if let fileData = FileManager.default.contents(atPath: vocabUrl.path()) {
+                if let fileData = FileManager.default.contents(atPath: vocabUrl.path) {
                     return fileData
                 } else {
                     throw TikTokenError.file
@@ -74,7 +74,7 @@ internal struct Vocab {
         
         if let vocabEncoderUrl = try getLocalVocabEncoderLocation() {
             if #available(iOS 16.0, *) {
-                if let fileData = FileManager.default.contents(atPath: vocabEncoderUrl.path()) {
+                if let fileData = FileManager.default.contents(atPath: vocabEncoderUrl.path) {
                     return fileData
                 } else {
                     throw TikTokenError.invalidEncoderParams
@@ -114,8 +114,8 @@ internal struct Vocab {
         var doesExist: Bool
         let appPath: String
         if #available(iOS 16.0, *) {
-            doesExist = FileManager.default.fileExists(atPath: appSupportDir.path())
-            appPath = appSupportDir.path()
+            doesExist = FileManager.default.fileExists(atPath: appSupportDir.path)
+            appPath = appSupportDir.path
         } else {
             var isDir: ObjCBool = true
             doesExist = FileManager.default.fileExists(atPath: appSupportDir.path, isDirectory: &isDir)
@@ -127,14 +127,7 @@ internal struct Vocab {
         }
         
         if #available(iOS 16.0, *) {
-            doesExist = FileManager.default.fileExists(atPath: appSupportDir.path())
-        } else {
-            var isDir: ObjCBool = true
-            doesExist = FileManager.default.fileExists(atPath: appSupportDir.path, isDirectory: &isDir)
-        }
-        
-        if #available(iOS 16.0, *) {
-            let created = FileManager.default.createFile(atPath: localFilePath.path(), contents: data)
+            let created = FileManager.default.createFile(atPath: localFilePath.path, contents: data)
             if !created {
                 throw TikTokenError.file
             }
@@ -162,7 +155,7 @@ internal struct Vocab {
         
         let doesExist: Bool
         if #available(iOS 16.0, *) {
-            doesExist = FileManager.default.fileExists(atPath: localFilePath.path())
+            doesExist = FileManager.default.fileExists(atPath: localFilePath.path)
         } else {
             var isDir: ObjCBool = false
             doesExist = FileManager.default.fileExists(atPath: localFilePath.path, isDirectory: &isDir)


### PR DESCRIPTION
I originally picked this library over the more popular one by aespinilla, because this one supported caching the vocab file. My goal was to put the vocab file in the bundle and copy it over to the support folder on launch so the app would be self contained.

Imagine my surprise when the caching didn't actually work because of the incorrect use of .path() instead of .path for the file system code.

This PR fixes all of the paths for reading and writing the vocab file.

Note: I did not test the writing of the file to the cache, because I'm not using that feature, but I did eyeball the code. Feel free to test before you merge. It's not likely this fix will make things worse.